### PR TITLE
ci: add auto-mirror workflow to sync main to STARS private repo

### DIFF
--- a/.github/workflows/mirror-to-stars.yml
+++ b/.github/workflows/mirror-to-stars.yml
@@ -1,0 +1,16 @@
+name: Mirror to STARS
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Push to STARS private mirror
+        run: git push https://x-access-token:${{ secrets.STARS_PAT }}@github.com/STARSAirAmbulance/presentation-builder-private.git HEAD:main


### PR DESCRIPTION
## Summary

Add a GitHub Action that automatically mirrors `main` to the STARS private repo after every push (including merged PRs). This eliminates the manual `git pull && git push` propagation step.

## How it works

1. PR merges on 3D-Stories → GitHub push event fires on `main`
2. This workflow checks out the repo and pushes to the corresponding `STARSAirAmbulance/*-private` repo
3. STARS marketplace has `auto_sync_on_push: true` → plugin install auto-refreshes

## Setup required

Add repository secret `STARS_PAT` with a GitHub PAT that has push access to the STARSAirAmbulance org. (Settings → Secrets and variables → Actions → New repository secret)

## Test plan

- [ ] Add `STARS_PAT` secret to repo
- [ ] Merge this PR
- [ ] Verify the mirror workflow runs successfully (Actions tab)
- [ ] Verify STARS-private `main` matches public `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)