### PR TITLE
fix(ci): strip whitespace from STARS_PAT in mirror workflow

### DIFF
--- a/.github/workflows/mirror-to-stars.yml
+++ b/.github/workflows/mirror-to-stars.yml
@@ -13,4 +13,8 @@ jobs:
           fetch-depth: 0
 
       - name: Push to STARS private mirror
-        run: git push https://x-access-token:${{ secrets.STARS_PAT }}@github.com/STARSAirAmbulance/presentation-builder-private.git HEAD:main
+        env:
+          STARS_PAT: ${{ secrets.STARS_PAT }}
+        run: |
+          PAT=$(echo "$STARS_PAT" | tr -d '[:space:]')
+          git push "https://x-access-token:${PAT}@github.com/STARSAirAmbulance/presentation-builder-private.git" HEAD:main


### PR DESCRIPTION
The PAT secret may contain a trailing newline from the source file, breaking the git push URL. Strips whitespace before use.