### PR TITLE
fix(ci): add persist-credentials: false to fix cross-org mirror push

### DIFF
--- a/.github/workflows/mirror-to-stars.yml
+++ b/.github/workflows/mirror-to-stars.yml
@@ -11,16 +11,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Diagnostic - verify PAT
-        env:
-          STARS_PAT: ${{ secrets.STARS_PAT }}
-        run: |
-          PAT=$(echo "$STARS_PAT" | tr -d '[:space:]')
-          echo "PAT length: ${#PAT}"
-          echo "PAT prefix: ${PAT:0:10}..."
-          echo "Testing git ls-remote..."
-          git ls-remote "https://x-access-token:${PAT}@github.com/STARSAirAmbulance/presentation-builder-private.git" HEAD 2>&1 || echo "ls-remote FAILED"
+          persist-credentials: false
 
       - name: Push to STARS private mirror
         env:


### PR DESCRIPTION
The checkout action's credential helper overrides the STARS_PAT in the push URL. Adding `persist-credentials: false` fixes it.