### PR TITLE
fix(ci): skip mirror workflow when running on STARS-private

### DIFF
--- a/.github/workflows/mirror-to-stars.yml
+++ b/.github/workflows/mirror-to-stars.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   mirror:
+    if: github.repository == '3D-Stories/presentation-builder'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The mirrored workflow fires on STARS-private too (push to main triggers it). Adds `if: github.repository` guard so it only runs on the 3D-Stories source repo.