### PR TITLE
iter-4 fix: Phase 8 gotcha #1 wording was backwards

### DIFF
--- a/skills/presentation-builder/references/phase-8-code-review.md
+++ b/skills/presentation-builder/references/phase-8-code-review.md
@@ -71,12 +71,26 @@ Before marking Phase 8 complete for PPTX builds, grep each build-deck
 file against these patterns. Each gotcha has caused a real runtime
 build failure in prior evaluations.
 
-1. **Shape constant casing.** The pptxgenjs shape enum is UPPERCASE.
-   `ShapeType.line` throws "Missing/Invalid shape parameter"; the
-   correct form is `ShapeType.LINE`. Check every `addShape` /
-   `ShapeType.` call and every string literal shape name. Common
-   offenders: `line`, `rect`, `ellipse`, `roundRect` (must be
-   `ROUND_RECT`).
+1. **Shape constant names.** pptxgenjs v4.x uses lowercase/camelCase
+   `ShapeType` constants — `rect`, `roundRect`, `line`, `ellipse`,
+   `diamond`, `arrow`, etc. Uppercase forms like `ShapeType.RECTANGLE`
+   or `ShapeType.LINE` do NOT exist and throw "Missing/Invalid shape
+   parameter" at runtime. Cross-check every `addShape` / `ShapeType.`
+   reference in the build-deck against the actual enum. `ShapeType`
+   lives on the instance, not the default export — write a one-off
+   script to enumerate valid names:
+
+   ```javascript
+   // /tmp/shapetype-check.js
+   const PptxGenJS = require('pptxgenjs');
+   const pres = new PptxGenJS();
+   console.log(Object.keys(pres.ShapeType).sort());
+   ```
+
+   Run with: `NODE_PATH=/home/rocky00717/.npm-global/lib/node_modules node /tmp/shapetype-check.js`
+
+   Any `ShapeType.XXX` reference in the build-deck whose name doesn't
+   appear in that output is a Must-fix.
 
 2. **Image path references match disk.** Every `addImage({ path: ... })`
    reference must resolve to an actual file. Cross-check the


### PR DESCRIPTION
## Summary

The iter-4 gotcha checklist (merged in #9) had Gotcha #1 backwards. I wrote "pptxgenjs shape enum is UPPERCASE (must be `ShapeType.LINE`, `ROUND_RECT`)." The empirical truth is the opposite: pptxgenjs v4.x uses lowercase/camelCase (`rect`, `roundRect`, `line`, `ellipse`). Uppercase forms throw at runtime.

Also fixes the enumeration command — `ShapeType` lives on the PptxGenJS instance, not the default export. Replaces the broken one-liner with a 3-line script.

## How this was found

The iter-4 verification run (1 subagent, team-update with_skill) ran the checklist end-to-end. The subagent caught a real bug (`ShapeType.RECTANGLE` — doesn't exist) and fixed it to `ShapeType.rect`. The fix was correct. But the checklist's guidance text said the opposite, so a reader without empirical validation would be led astray.

## Test plan

- [x] Confirmed via `node -e` on pptxgenjs@4.0.1 that `ShapeType` is on the instance and keys are camelCase (`accentBorderCallout1`, `accentCallout1`, `actionButtonBackPrevious`, etc.)
- [ ] No re-run needed — pure documentation correction

🤖 Generated with [Claude Code](https://claude.com/claude-code)