### PR TITLE
chore: add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Rawgentic project-local config
+.rawgentic.json
+
+# Iteration-1 eval workspace (never committed; pre-hardening baseline,
+# superseded by iteration-2/iteration-3 results already in repo)
+presentation-builder-workspace/iteration-1/
+
+# Node
+node_modules/


### PR DESCRIPTION
## Summary

Add `.gitignore` covering the two items called out in session cleanup:

- `.rawgentic.json` — rawgentic project-local config, shouldn't be committed
- `presentation-builder-workspace/iteration-1/` — pre-hardening eval baseline, never committed; superseded by iteration-2/3 already in-tree

Also pre-emptively excludes `node_modules/` so ad-hoc build-deck experiments don't leak in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)