### PR TITLE
feat(skill): add Phase 0 — template extraction for branded PPTX

### DIFF
--- a/skills/presentation-builder/SKILL.md
+++ b/skills/presentation-builder/SKILL.md
@@ -77,6 +77,9 @@ The workflow has three user-facing stages with internal phases. At each check-in
 progress indicator so the user always knows where they are.
 
 ```
+STAGE 0: TEMPLATE (conditional — only when user provides a branded PPTX)
+  Phase 0: Template Analysis ───→ template-analysis.md + template-assets/
+
 STAGE 1: DISCOVERY
   Phase 1: Research & Gather ──→ MATERIALS_INDEX.md
   Phase 2: Requirements ────────→ Presentation design spec
@@ -106,6 +109,7 @@ If invoked in a directory with existing presentation artifacts, detect partial p
 
 | If this exists... | Resume from... |
 |-------------------|----------------|
+| `template-analysis.md` only | Phase 1 (Research) or Phase 2 (Requirements) |
 | `MATERIALS_INDEX.md` only | Phase 2 (Requirements) |
 | Design spec in `docs/superpowers/specs/` | Phase 3 (Review) |
 | `style-guide.md` | Phase 5 (Design Review) or Phase 6 (Visuals) |
@@ -117,6 +121,20 @@ Present what was found and ask: "It looks like you have a presentation in progre
 pick up where you left off, or start fresh?"
 
 ## Phase Details
+
+### Phase 0: Template Analysis (conditional)
+
+Read `references/phase-0-template.md` for the detailed process.
+
+**Summary:** When the user provides an existing branded PPTX template, extract colors, fonts,
+and media assets from it. Unzip the PPTX, parse `ppt/theme/theme1.xml` for the color scheme
+and font families, copy `ppt/media/*` to `template-assets/`, rename assets to semantic names,
+and generate `template-analysis.md` at the project root.
+
+**When to run:** Ask during initial setup whether the user has a branded PPTX template. If yes,
+run Phase 0 before Phase 1. If no template, skip entirely.
+
+**Outputs:** `template-analysis.md` + `template-assets/` directory with renamed assets.
 
 ### Phase 1: Research & Gather
 

--- a/skills/presentation-builder/references/phase-0-template.md
+++ b/skills/presentation-builder/references/phase-0-template.md
@@ -1,0 +1,235 @@
+# Phase 0: Template Analysis
+
+## Prerequisite
+
+Phase 0 runs ONLY when the user provides an existing PPTX template file.
+If no template is provided, SKIP this phase entirely and advance to Phase 1.
+
+Ask during initial setup:
+
+> "Do you have an existing branded PPTX template I should extract colors,
+> fonts, and assets from? If so, provide the file path."
+
+If the user provides a template path, verify it exists and has a `.pptx`
+extension before proceeding. If it doesn't exist, ask again.
+
+## Process
+
+### 1. Unzip the PPTX
+
+PPTX files are ZIP archives. Extract to a temp directory:
+
+```bash
+TEMPLATE_DIR=$(mktemp -d)
+unzip -o "<template-path>" -d "$TEMPLATE_DIR"
+```
+
+The relevant internal structure:
+
+```
+ppt/
+  theme/
+    theme1.xml        -- Brand colors and fonts
+  slideMasters/
+    slideMaster1.xml  -- Master slide layouts
+  slideLayouts/
+    slideLayout*.xml  -- Individual layout definitions
+  media/
+    image1.png        -- Logos, backgrounds, patterns, photos
+    image2.jpg
+    ...
+```
+
+### 2. Extract media assets
+
+Copy all files from `ppt/media/` to `template-assets/` in the project root:
+
+```bash
+mkdir -p template-assets
+cp "$TEMPLATE_DIR"/ppt/media/* template-assets/ 2>/dev/null || true
+```
+
+Count the extracted assets:
+
+```bash
+ls template-assets/ | wc -l
+```
+
+If 0 assets extracted, note this in the analysis — the template uses only
+shapes and colors with no embedded images.
+
+### 3. Parse theme XML
+
+Read `ppt/theme/theme1.xml` and extract:
+
+**Color scheme** (`a:clrScheme`):
+- `dk1` / `dk2` — dark colors (typically text on light backgrounds)
+- `lt1` / `lt2` — light colors (typically text on dark backgrounds)
+- `accent1` through `accent6` — brand accent colors
+- `hlink` / `folHlink` — hyperlink colors
+
+Each color element contains either:
+- `<a:srgbClr val="RRGGBB"/>` — direct hex color
+- `<a:sysClr val="windowText" lastClr="000000"/>` — system color with fallback
+
+Extract ALL hex values. Map each to its role.
+
+**Font scheme** (`a:fontScheme`):
+- `majorFont` → title/heading font family
+- `minorFont` → body text font family
+
+Each font element has `<a:latin typeface="FontName"/>` — extract the typeface.
+
+**Parsing approach:**
+Use `grep` and `sed` for extraction — do NOT install XML parsing libraries.
+The theme XML structure is consistent across PowerPoint versions:
+
+```bash
+# Colors
+grep -oP 'name="[^"]*"' "$TEMPLATE_DIR/ppt/theme/theme1.xml" | head -20
+grep -oP 'srgbClr val="[A-Fa-f0-9]{6}"' "$TEMPLATE_DIR/ppt/theme/theme1.xml"
+grep -oP 'lastClr="[A-Fa-f0-9]{6}"' "$TEMPLATE_DIR/ppt/theme/theme1.xml"
+
+# Fonts
+grep -oP 'typeface="[^"]*"' "$TEMPLATE_DIR/ppt/theme/theme1.xml" | sort -u
+```
+
+### 4. Classify and rename assets
+
+For each file in `template-assets/`, determine what it is:
+
+**Classification by inspection:**
+- Check dimensions: wide/short images are likely backgrounds or banners
+- Check file size: very small files (<5KB) are likely icons or decorative elements
+- Check format: SVG/EMF files are vector graphics (logos, shapes)
+- Check transparency: PNG files with alpha channel are likely logos or overlays
+
+**Naming convention:**
+Rename from generic names to semantic names:
+
+| Original | Renamed to | Classification |
+|----------|-----------|----------------|
+| `image1.png` | `logo-primary.png` | Logo (transparent, small) |
+| `image2.jpg` | `bg-dark-gradient.jpg` | Background (wide, dark) |
+| `image3.png` | `pattern-diagonal.png` | Pattern (repeating, decorative) |
+| `image4.jpg` | `photo-hero.jpg` | Photo (large, photographic) |
+
+Use these heuristics:
+- **Transparent PNG with text/symbol** → `logo-*.png`
+- **Full-slide dimensions (wide)** → `bg-*.{jpg,png}`
+- **Repeating pattern or stripe** → `pattern-*.{jpg,png}`
+- **Photographic content** → `photo-*.{jpg,png}`
+- **Small decorative element** → `decor-*.{jpg,png}`
+- **Icon or symbol** → `icon-*.{jpg,png}`
+
+If classification is uncertain, prefix with `unknown-` and note it in the
+analysis for user review.
+
+Rename command pattern:
+```bash
+mv template-assets/image1.png template-assets/logo-primary.png
+```
+
+### 5. Generate template-analysis.md
+
+Write `template-analysis.md` at the project root with all extracted data:
+
+```markdown
+# Template Analysis
+
+Extracted from: `<original-filename>.pptx`
+Date: YYYY-MM-DD
+
+## Color Palette
+
+| Role | Hex | Name | Usage |
+|------|-----|------|-------|
+| Dark 1 | `RRGGBB` | [name] | Primary text on light backgrounds |
+| Dark 2 | `RRGGBB` | [name] | Secondary text |
+| Light 1 | `RRGGBB` | [name] | Text on dark backgrounds |
+| Light 2 | `RRGGBB` | [name] | Secondary light text |
+| Accent 1 | `RRGGBB` | [name] | Primary brand accent |
+| Accent 2 | `RRGGBB` | [name] | Secondary accent |
+| ... | ... | ... | ... |
+
+## Font Families
+
+| Role | Font | Fallback |
+|------|------|----------|
+| Titles (majorFont) | [extracted font] | [system-safe alternative] |
+| Body (minorFont) | [extracted font] | [system-safe alternative] |
+
+## Extracted Assets
+
+| File | Classification | Dimensions | Notes |
+|------|---------------|------------|-------|
+| `template-assets/logo-primary.png` | Logo | NxN | Transparent background |
+| `template-assets/bg-dark-gradient.jpg` | Background | NxN | Dark slide background |
+| ... | ... | ... | ... |
+
+## Slide Layout Summary
+
+[Brief description of the template's slide master patterns:
+which layouts exist, which use dark vs light backgrounds,
+where logos are placed, etc.]
+
+## Recommendations for Style Guide
+
+- **Primary color:** [hex] — use for section dividers and title slides
+- **Secondary color:** [hex] — use for content slide accents
+- **Title font:** [font name] — verify availability on target system
+- **Body font:** [font name] — verify availability on target system
+- **Reusable assets:** [list which extracted assets to use in the deck]
+- **Assets to skip:** [list which are template-specific chrome not needed]
+```
+
+### 6. Clean up
+
+Remove the temp directory:
+
+```bash
+rm -rf "$TEMPLATE_DIR"
+```
+
+## Phase-complete gate
+
+Phase 0 is NOT complete until ALL of the following hold:
+
+1. `template-analysis.md` exists at the project root.
+2. `template-analysis.md` contains a Color Palette table with at least 4
+   colors extracted (dk1, lt1, accent1, accent2 minimum).
+3. `template-analysis.md` contains a Font Families table with at least 2
+   rows (major and minor font).
+4. `template-assets/` directory exists and contains the extracted files
+   (count matches the number listed in the Assets table).
+5. Assets have been renamed from generic names to semantic names (no
+   `imageN.{ext}` files remain unless classification was genuinely
+   impossible — in which case the file is prefixed `unknown-`).
+
+If the template has 0 media files, gate condition (4) is relaxed: the
+directory must exist but may be empty. Note "0 media assets" in the
+analysis.
+
+## Downstream integration
+
+Phase 0 outputs feed into later phases:
+
+- **Phase 2** detects `template-analysis.md` and uses the extracted palette
+  and fonts as default suggestions during Q1-Q8 brainstorming (the user
+  can still override).
+- **Phase 4** reads `template-analysis.md` and pre-populates the style
+  guide's color palette and typography sections from the extracted data
+  instead of offering generic palette options.
+- **Phase 7** can reference `template-assets/` for logos and backgrounds
+  to embed in the build scripts.
+
+## Known limitations
+
+- Theme XML parsing via grep/sed handles standard PowerPoint themes but
+  may miss colors defined in slide masters or custom XML parts. If the
+  extracted palette looks incomplete, inspect `slideMaster1.xml` manually.
+- Font availability cannot be verified at extraction time — the extracted
+  font names may not be installed on the build machine. Phase 4 should
+  specify fallbacks.
+- Asset classification is heuristic-based. Always present the renamed
+  assets to the user for confirmation before Phase 2.

--- a/skills/presentation-builder/references/phase-2-requirements.md
+++ b/skills/presentation-builder/references/phase-2-requirements.md
@@ -7,6 +7,21 @@ This is the most important phase -- shift-left means spending the most effort he
 
 ## Process
 
+### 0. Detect template analysis
+
+Before starting questions, check if `template-analysis.md` exists at the
+project root (produced by Phase 0). If it does:
+
+1. Read the extracted color palette and font families.
+2. Use them as **defaults** in Q-series questions — present the template
+   colors as the recommended palette and the template fonts as the
+   recommended typography. The user can still override.
+3. Reference specific template assets when discussing visual strategy (Q8)
+   — e.g., "Your template includes a dark gradient background and a
+   primary logo. Want to reuse these?"
+
+If `template-analysis.md` does not exist, proceed normally.
+
 ### 1. Core Questions (One at a Time)
 
 Ask these questions one per message, in order. Use multiple choice where possible.

--- a/skills/presentation-builder/references/phase-4-style-guide.md
+++ b/skills/presentation-builder/references/phase-4-style-guide.md
@@ -8,9 +8,34 @@ deck from a collection of slides.
 
 ## Process
 
+### 0. Check for template analysis
+
+Before offering palette choices, check if `template-analysis.md` exists at
+the project root (produced by Phase 0).
+
+If it exists:
+1. Read the extracted color palette and font families.
+2. **Pre-populate** the style guide's color palette (step 1) and typography
+   (step 2) from the template data instead of offering generic options.
+3. Present the pre-populated values to the user: "Your template uses
+   [font] for titles and [font] for body text, with [hex] as the primary
+   accent. I'll use these in the style guide — let me know if you want
+   to change anything."
+4. Skip the "Suggested palettes" table below — the template IS the palette.
+5. Reference extracted assets in the visual motifs section (step 5) —
+   e.g., if the template has a diagonal stripe pattern, use it as a
+   recurring motif.
+
+If `template-analysis.md` does not exist, proceed with the standard
+palette selection below.
+
 ### 1. Choose a Color Palette
 
 Pick colors that match the TOPIC, not generic blue. Consider the audience and setting.
+
+**If template colors are available** (from step 0), use those directly and
+skip the suggested palettes. Only offer the table below as alternatives
+if the user wants to deviate from their brand.
 
 Suggested palettes (or create a custom one):
 
@@ -32,6 +57,10 @@ Define roles for each color:
 
 ### 2. Define Typography
 
+If `template-analysis.md` exists, use the extracted majorFont for titles
+and minorFont for body text. Fill in the table with those fonts and verify
+the user is happy with them before proceeding.
+
 | Element | Font | Size | Weight |
 |---------|------|------|--------|
 | Slide title | ... | 36-44pt | Bold |
@@ -41,7 +70,8 @@ Define roles for each color:
 | Stats/big numbers | ... | 54-60pt | Bold |
 | Captions | ... | 10-12pt | Regular |
 
-Use system-safe fonts unless the user specifies custom ones.
+Use system-safe fonts unless the user specifies custom ones or a template
+analysis provides brand fonts.
 
 ### 3. Define Slide Structure Patterns
 


### PR DESCRIPTION
## Summary

- Adds Phase 0 reference file (`references/phase-0-template.md`) with full process for extracting colors, fonts, and media assets from branded PPTX templates
- Updates SKILL.md with Phase 0 in the workflow diagram, resumption table, and phase details section
- Updates Phase 2 to detect `template-analysis.md` and use extracted palette/fonts as default suggestions
- Updates Phase 4 to pre-populate the style guide from template data instead of offering generic palettes

Closes #13

## Design Decisions

- Phase 0 is **conditional** — only runs when user provides a template, skipped otherwise
- Uses `grep`/`sed` for XML parsing rather than installing dependencies — sufficient for standard PowerPoint theme XML
- Asset classification uses heuristics (dimensions, transparency, file size) with `unknown-` prefix fallback for uncertain cases
- Template data feeds downstream as **defaults** that users can override, not hard constraints

## Test plan

- [ ] Verify Phase 0 reference file covers unzip → extract → parse → rename → analysis flow
- [ ] Verify SKILL.md workflow diagram shows Phase 0 as conditional stage
- [ ] Verify Phase 2 step 0 checks for `template-analysis.md` and uses as defaults
- [ ] Verify Phase 4 step 0 pre-populates palette/typography from template
- [ ] Verify phase-complete gate checks all 5 conditions
- [ ] Run skill against a real branded PPTX template to validate end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)