### PR TITLE
fix(skill): add WSL2 detection and MCP environment pre-flight

### DIFF
--- a/skills/presentation-builder/references/setup.md
+++ b/skills/presentation-builder/references/setup.md
@@ -5,6 +5,47 @@
 Run these checks in sequence on first invocation. After all pass, create
 `~/.claude/.presentation-builder-setup-complete` (global marker -- prerequisites are machine-level).
 
+### 0. Environment Pre-flight (WSL2 detection)
+
+Before any dependency checks, detect the runtime environment. WSL2 has a
+known failure mode where Windows binaries on PATH shadow Linux equivalents,
+causing silent MCP setup failures.
+
+```bash
+if uname -r 2>/dev/null | grep -qi microsoft; then
+  echo "WSL2 environment detected"
+
+  # Check if npx resolves to a Windows binary
+  NPX_PATH=$(which npx 2>/dev/null)
+  if echo "$NPX_PATH" | grep -q '/mnt/c/'; then
+    echo "WARNING: npx resolves to Windows binary: $NPX_PATH"
+    echo "MCP servers launched with this npx will fail silently."
+    echo "Fix: install Node.js natively in WSL2:"
+    echo "  sudo apt update && sudo apt install -y nodejs npm"
+    echo "  OR use nvm: https://github.com/nvm-sh/nvm"
+  fi
+
+  # Check if node resolves to a Windows binary
+  NODE_PATH_CHECK=$(which node 2>/dev/null)
+  if echo "$NODE_PATH_CHECK" | grep -q '/mnt/c/'; then
+    echo "WARNING: node resolves to Windows binary: $NODE_PATH_CHECK"
+    echo "Fix: install Node.js natively in WSL2 (same as above)"
+  fi
+fi
+```
+
+If warnings are printed, **STOP** and tell the user:
+
+> "Your WSL2 environment has Windows Node.js on PATH instead of Linux
+> Node.js. MCP servers (including Replicate for image generation) will
+> fail silently with this configuration. Install Node.js natively in WSL2
+> before continuing:
+> `sudo apt update && sudo apt install -y nodejs npm`
+> Then restart Claude Code."
+
+Do NOT proceed with setup if npx resolves to a `/mnt/c/` path — the
+Replicate MCP server will fail to start and Phase 6 will be unreachable.
+
 ### 1. document-skills Plugin
 
 ```bash
@@ -69,6 +110,29 @@ If the user chooses (a), change Q8 to `text-only` in the design spec and continu
 The prior "I can design the presentation and create placeholder slides
 for images" language has been removed — it was a silent-downgrade path
 that let Sonnet skip image generation without user opt-in.
+
+**Post-setup MCP connectivity test:**
+
+After the user runs `/generate-image:setup` and reconnects MCP, verify
+the Replicate tools are actually available before continuing:
+
+```bash
+# Check that Replicate MCP tools loaded successfully
+# In the Claude Code session, mcp__replicate__* tools should be visible.
+# If they are not, the MCP server failed to start.
+```
+
+If tools are still not visible after setup:
+1. Check MCP server status: `claude mcp list`
+2. On WSL2: re-run the environment pre-flight (step 0) — Windows npx is
+   the most common cause of "setup succeeded but tools not available"
+3. Try restarting Claude Code entirely (not just `/mcp` reconnect)
+
+If the MCP server is listed but tools don't appear, the server is crashing
+at startup. Common causes:
+- Invalid or expired Replicate API token
+- Network connectivity issues (corporate proxy, VPN)
+- npx version incompatibility (try `npx@latest`)
 
 ### 3. Review Tools (Optional)
 


### PR DESCRIPTION
## Summary

- Adds environment pre-flight step (step 0) to `setup.md` that detects WSL2 via `uname -r` and warns if `npx`/`node` resolve to Windows binaries under `/mnt/c/`
- Blocks setup if Windows binaries are detected — prevents the silent MCP failure chain that caused 3 session restarts in the field retrospective
- Adds post-setup MCP connectivity test with troubleshooting steps for common failure modes (expired token, proxy, npx version)

Closes #14

## Test plan

- [ ] On WSL2 with Windows Node.js on PATH: verify warning is printed and setup halts
- [ ] On WSL2 with native Linux Node.js: verify no warning and setup proceeds normally
- [ ] On native Linux (non-WSL): verify pre-flight is skipped silently
- [ ] After `/generate-image:setup`: verify MCP connectivity test guidance is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)