### PR TITLE
feat(skill): add post-build PPTX validation (media, format, contrast, notes)

### DIFF
--- a/skills/presentation-builder/SKILL.md
+++ b/skills/presentation-builder/SKILL.md
@@ -252,24 +252,27 @@ A common Sonnet failure pattern is reviewing code without running the build. Do 
 
 ### Phase 9: Build & Iterate
 
-Run the build script to generate the presentation file:
+Read `references/phase-9-build.md` for the detailed process, including post-build PPTX
+validation (media count, format verification, contrast check, speaker notes check).
 
-```bash
-cd build-deck && node build.js
-```
+**Summary:** Run the build, then validate the generated file structurally. For PPTX, unzip
+and inspect: verify media count matches the image plan, check for 0-byte files, validate
+image formats via magic bytes (catches WebP-as-PNG), and verify speaker notes exist on every
+slide. Run contrast validation on all text/background combinations.
 
 **Phase-complete gate:** Phase 9 is NOT complete until:
 
 1. The output file exists at the expected path (e.g., `output.pptx`).
 2. The output file size exceeds the minimum threshold:
-   - PPTX: ≥ 10 KB
-   - PDF: ≥ 5 KB
-   - DOCX: ≥ 5 KB
-   - HTML: ≥ 5 KB
-3. The slide count in the output matches the spec's total slide count
-   (pptxgenjs' built-in assertion in `build.js` covers this; parse the
-   generated file for other formats if needed).
+   - PPTX: >= 10 KB
+   - PDF: >= 5 KB
+   - DOCX: >= 5 KB
+   - HTML: >= 5 KB
+3. The slide count matches the spec's total slide count.
 4. The build invocation is recorded in the transcript (exit code captured).
+5. **(PPTX only)** Post-build validation passed — no 0-byte media, no format mismatches,
+   no contrast ratio below 3:1.
+6. Any Must-fix validation failures have been resolved and the build re-run.
 
 NOTE: Phase 7's build gate partially overlaps this one — that is
 intentional. Phase 7 requires the build was made to work during
@@ -279,11 +282,11 @@ edits. Belt-and-suspenders redundancy is deliberate for Sonnet reliability.
 A common Sonnet failure pattern is declaring Phase 9 complete based on
 build scripts existing rather than on actually running them. Do NOT skip
 the build invocation — the build script must execute and produce a file
-on disk that passes the size and slide-count checks.
+on disk that passes the size, slide-count, AND structural validation checks.
 
 Iterate based on user feedback using the iteration protocol below.
 
-**Outputs:** Final presentation file.
+**Outputs:** Final validated presentation file.
 
 ## Iteration Protocol
 

--- a/skills/presentation-builder/references/phase-7-implementation.md
+++ b/skills/presentation-builder/references/phase-7-implementation.md
@@ -36,7 +36,31 @@ Translates the style guide into code. Must include:
 - `addCard(slide, pres, { x, y, w, h, accentColor })` -- card with left accent border
 - `addStat(slide, { x, y, number, label, color })` -- big stat callout
 - `addCode(slide, pres, { x, y, w, h, code })` -- dark code block
+- `contrastCheck(fg, bg)` -- WCAG contrast ratio validation (see below)
 - Any recurring visual patterns from the style guide
+
+**Contrast validation function** (include in every theme.js):
+```javascript
+function contrastCheck(fg, bg) {
+  function luminance(hex) {
+    const r = parseInt(hex.slice(0, 2), 16) / 255;
+    const g = parseInt(hex.slice(2, 4), 16) / 255;
+    const b = parseInt(hex.slice(4, 6), 16) / 255;
+    const [rs, gs, bs] = [r, g, b].map(c =>
+      c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+    );
+    return 0.2126 * rs + 0.7152 * gs + 0.0722 * bs;
+  }
+  const l1 = luminance(fg), l2 = luminance(bg);
+  const ratio = (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05);
+  if (ratio < 3) console.error(`CONTRAST FAIL: ${fg} on ${bg} = ${ratio.toFixed(2)}:1 (< 3:1, invisible)`);
+  else if (ratio < 4.5) console.warn(`CONTRAST WARN: ${fg} on ${bg} = ${ratio.toFixed(2)}:1 (< 4.5:1, fails WCAG AA)`);
+  return ratio;
+}
+```
+Call `contrastCheck` for every text color / background color pair defined
+in the `colors` object. Run these checks at build time (in `build.js`
+before generating slides) so warnings appear in the build output.
 
 ### slides-sN.js
 

--- a/skills/presentation-builder/references/phase-8-code-review.md
+++ b/skills/presentation-builder/references/phase-8-code-review.md
@@ -64,6 +64,14 @@ Focus on:
   for the "good notes (speakable script)" standard.
 - **pptxgenjs API gotchas** (see checklist below) — each one has been
   observed to ship undetected by a less-rigorous Phase 8 review.
+- **Contrast validation** — verify the build script calls `contrastCheck()`
+  for all text/background pairs. Any ratio < 3:1 is a Must-fix. See
+  `references/phase-7-implementation.md` for the `contrastCheck` function.
+- **Post-build validation readiness** — verify the build script or a
+  companion validation script implements the checks from
+  `references/phase-9-build.md` (media count, 0-byte detection, format
+  validation, speaker notes). Phase 9 will run these checks on the output
+  file — but Phase 8 should confirm the code to perform them exists.
 
 ## pptxgenjs API gotcha checklist (PPTX format only)
 

--- a/skills/presentation-builder/references/phase-9-build.md
+++ b/skills/presentation-builder/references/phase-9-build.md
@@ -1,0 +1,175 @@
+# Phase 9: Build & Iterate
+
+## Purpose
+
+Run the final build, validate the output structurally, and iterate based
+on user feedback. Phase 9 is the last quality gate before the presentation
+is delivered.
+
+## Process
+
+### 1. Run the build
+
+```bash
+cd build-deck && node build.js 2>&1 | tee ../build-output.log ; echo "EXIT=$?"
+```
+
+Record the exit code. If non-zero, fix and re-run before proceeding.
+
+### 2. Post-build PPTX validation (PPTX format only)
+
+After a successful build (exit code 0), inspect the generated PPTX file
+structurally. A PPTX is a ZIP archive — extract and verify its contents.
+
+```bash
+PPTX_PATH="output.pptx"  # adjust to actual output path
+PPTX_CHECK=$(mktemp -d)
+unzip -o "$PPTX_PATH" -d "$PPTX_CHECK"
+```
+
+Run ALL of the following checks. A failure in ANY check is a **Must-fix**
+finding — do not deliver the presentation until resolved.
+
+#### 2a. Media count check
+
+```bash
+EXPECTED_MEDIA=<number from style guide image plan>
+ACTUAL_MEDIA=$(ls "$PPTX_CHECK"/ppt/media/ 2>/dev/null | wc -l)
+echo "Media files: expected=$EXPECTED_MEDIA actual=$ACTUAL_MEDIA"
+```
+
+If `ACTUAL_MEDIA < EXPECTED_MEDIA`, images were lost during build. Check
+`addImage` calls against the image plan. If `ACTUAL_MEDIA == 0` and
+images were expected, the image loading method is likely wrong (see Phase
+7 pitfall: use `data` not `path`).
+
+Note: pptxgenjs may embed additional media (e.g., slide backgrounds
+defined via shapes). `ACTUAL_MEDIA >= EXPECTED_MEDIA` is acceptable;
+`ACTUAL_MEDIA < EXPECTED_MEDIA` is a failure.
+
+#### 2b. Zero-byte file detection
+
+```bash
+find "$PPTX_CHECK"/ppt/media/ -size 0 -print
+```
+
+Any 0-byte file is a **Must-fix**. A 0-byte media file means the image
+was referenced but empty — PowerPoint will show a broken placeholder.
+
+#### 2c. Image format validation (magic bytes)
+
+```bash
+for f in "$PPTX_CHECK"/ppt/media/*; do
+  MAGIC=$(xxd -l 4 -p "$f" 2>/dev/null)
+  EXT="${f##*.}"
+  case "$MAGIC" in
+    89504e47*) FORMAT="PNG" ;;
+    ffd8ff*)   FORMAT="JPEG" ;;
+    52494646*) FORMAT="WebP" ;;
+    *)         FORMAT="UNKNOWN($MAGIC)" ;;
+  esac
+  echo "$(basename $f): $FORMAT"
+
+  # Flag mismatches
+  if [ "$EXT" = "png" ] && [ "$FORMAT" = "WebP" ]; then
+    echo "  ERROR: $f is WebP masquerading as PNG — PowerPoint cannot display"
+  fi
+  if [ "$FORMAT" = "WebP" ]; then
+    echo "  ERROR: WebP file embedded — pptxgenjs has limited WebP support"
+  fi
+done
+```
+
+Any format mismatch or WebP file is a **Must-fix**. Convert to PNG before
+re-building.
+
+#### 2d. Speaker notes existence check
+
+```bash
+SLIDE_COUNT=0
+NOTES_MISSING=0
+for slide in "$PPTX_CHECK"/ppt/slides/slide*.xml; do
+  SLIDE_COUNT=$((SLIDE_COUNT + 1))
+  NUM=$(basename "$slide" | grep -oP '\d+')
+  NOTES_FILE="$PPTX_CHECK/ppt/notesSlides/notesSlide${NUM}.xml"
+  if [ ! -f "$NOTES_FILE" ]; then
+    echo "WARNING: Slide $NUM has no speaker notes file"
+    NOTES_MISSING=$((NOTES_MISSING + 1))
+  elif ! grep -q '<a:t>' "$NOTES_FILE" 2>/dev/null; then
+    echo "WARNING: Slide $NUM has empty speaker notes"
+    NOTES_MISSING=$((NOTES_MISSING + 1))
+  fi
+done
+echo "Speaker notes: $((SLIDE_COUNT - NOTES_MISSING))/$SLIDE_COUNT slides have notes"
+```
+
+Missing or empty speaker notes is a **Should-fix** (not blocking, but the
+skill mandates comprehensive notes on every slide). Flag in the review log.
+
+#### 2e. Clean up
+
+```bash
+rm -rf "$PPTX_CHECK"
+```
+
+### 3. Color contrast validation (at build time)
+
+The `contrastCheck()` function in `theme.js` (see Phase 7 reference)
+should be called during the build to validate all text/background color
+combinations. Any pair below WCAG AA ratio (4.5:1 for normal text, 3:1
+for large text) should print a warning.
+
+Build scripts should call this for every text element's color against its
+slide background:
+- Light slide background vs body text color
+- Dark slide background vs light text color
+- Card background vs card text color
+- Stat number color vs slide background
+
+A contrast ratio below 3:1 is a **Must-fix** (text is effectively
+invisible). A ratio between 3:1 and 4.5:1 is a **Should-fix** (readable
+but fails WCAG AA).
+
+### 4. Iterate
+
+After validation passes, present the output to the user. Iterate based on
+feedback using the modular architecture — content changes touch one
+`slides-sN.js` file, style changes touch `theme.js`, etc.
+
+Re-run the post-build validation after every rebuild.
+
+## Phase-complete gate
+
+Phase 9 is NOT complete until ALL of the following hold:
+
+1. The output file exists at the expected path.
+2. The output file size exceeds the minimum threshold:
+   - PPTX: >= 10 KB
+   - PDF: >= 5 KB
+   - DOCX: >= 5 KB
+   - HTML: >= 5 KB
+3. The slide count matches the spec's total slide count.
+4. The build invocation is recorded in the transcript (exit code captured).
+5. **(PPTX only)** Post-build validation passed:
+   - Media count >= expected count
+   - No 0-byte media files
+   - No WebP files or format mismatches in embedded media
+   - No contrast ratio below 3:1 (Must-fix threshold)
+6. Any Must-fix validation failures have been resolved and the build
+   re-run.
+
+A common Sonnet failure pattern is declaring Phase 9 complete based on
+build scripts existing rather than on actually running them AND validating
+the output. The build must execute, produce a file, and that file must
+pass structural validation.
+
+## Known failure modes
+
+- **Build exits 0 but images are broken.** The `path` property in
+  pptxgenjs fails silently. Post-build media count check catches this.
+- **WebP disguised as PNG.** AI image tools return WebP saved with `.png`
+  extension. Magic byte check catches this.
+- **Invisible text.** Low-contrast text (e.g., `E7E6E6` on white) is not
+  a build error. Contrast validation catches this.
+- **Empty speaker notes.** pptxgenjs creates the notes slide structure
+  even for empty strings. The `<a:t>` content check catches this.


### PR DESCRIPTION
## Summary

- Creates `references/phase-9-build.md` with full post-build validation process for PPTX output
- Adds media count check (expected vs embedded), 0-byte file detection, magic byte format validation (catches WebP-as-PNG), and speaker notes existence check
- Adds `contrastCheck(fg, bg)` WCAG luminance ratio function to Phase 7 theme.js template — warns at build time for contrast < 4.5:1, errors for < 3:1
- Updates Phase 8 review checklist to verify validation code exists before Phase 9 runs it
- Updates SKILL.md Phase 9 section to point to new reference file with expanded phase-complete gate

Closes #15

## Design Decisions

- Validation is bash-based (unzip + grep/xxd) rather than requiring a Node.js PPTX parser — keeps dependencies minimal
- Speaker notes check is Should-fix (not Must-fix) since the skill already mandates notes in Phase 7 — this is a safety net
- Contrast thresholds: < 3:1 is Must-fix (invisible), 3:1-4.5:1 is Should-fix (fails WCAG AA but readable)

## Test plan

- [ ] Verify `phase-9-build.md` covers all 4 validation checks (media count, 0-byte, format, notes)
- [ ] Verify `contrastCheck()` function computes correct WCAG ratio (e.g., E7E6E6 on FFFFFF should fail)
- [ ] Verify Phase 8 checklist includes contrast and post-build validation readiness
- [ ] Verify SKILL.md Phase 9 gate includes structural validation conditions
- [ ] End-to-end: build a PPTX with a known-bad image, verify validation catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)