### PR TITLE
feat(skill): add P3 nice-to-haves — preview, notes export, costs, fonts, templates

### DIFF
--- a/skills/presentation-builder/references/phase-6-visuals.md
+++ b/skills/presentation-builder/references/phase-6-visuals.md
@@ -121,6 +121,32 @@ and PowerPoint may fail to display it. If `/generate-image` returns a
 WebP file (check magic bytes, not extension), convert to PNG before
 proceeding.
 
+## Cost tracking
+
+Track cumulative Replicate API costs during image generation. After each
+`/generate-image` invocation, log the model used and estimated cost:
+
+| Model | Approx. cost per image |
+|-------|----------------------|
+| Nano Banana 2 | ~$0.01-0.02 |
+| FLUX Schnell | ~$0.003-0.01 |
+| Background removal | ~$0.01-0.02 |
+
+After all images are generated, print a cost summary:
+
+```
+Image Generation Cost Summary
+=============================
+Images generated: 7
+  - AI generated: 5 (Nano Banana 2)
+  - Background removed: 3
+  - Programmatic: 2 (no API cost)
+Estimated total: ~$0.13
+```
+
+This is informational — do not block on cost. Present the summary to the
+user after Phase 6 completes so they have visibility into API usage.
+
 ## Image generation tips
 
 - **Be specific** in prompts: "a gold trophy with two handles" not "an award".

--- a/skills/presentation-builder/references/phase-7-implementation.md
+++ b/skills/presentation-builder/references/phase-7-implementation.md
@@ -178,6 +178,86 @@ In all cases, maintain the modular principle -- separate files per section.
 ### General
 - **Test build after every change** -- don't batch multiple untested changes
 
+## Font availability check
+
+pptxgenjs silently substitutes fonts when the specified font is not
+installed on the build machine. Add a check to `build.js` that runs
+before slide generation:
+
+```javascript
+const { execFileSync } = require('child_process');
+
+function checkFont(fontName) {
+  try {
+    const installed = execFileSync('fc-list', [':' , 'family'], { encoding: 'utf8' });
+    if (!installed.toLowerCase().includes(fontName.toLowerCase())) {
+      console.warn(`FONT WARNING: "${fontName}" not found on this system.`);
+      console.warn(`  pptxgenjs will silently substitute a default font.`);
+      console.warn(`  Install it, or update theme.js with a fallback.`);
+      return false;
+    }
+    return true;
+  } catch (e) {
+    return true; // fc-list not available (Windows), skip check
+  }
+}
+
+// Run at build start
+const { fonts } = require('./theme');
+checkFont(fonts.title);
+checkFont(fonts.body);
+```
+
+Define a fallback chain in `theme.js` for each brand font:
+
+```javascript
+const fonts = {
+  title: 'Rubik',         // brand font
+  titleFallback: 'Arial', // safe fallback if brand font unavailable
+  body: 'Rubik',
+  bodyFallback: 'Calibri',
+  code: 'Consolas',
+};
+```
+
+The build script should warn but not fail — font substitution is cosmetic,
+not a broken build. The user can install the font or accept the fallback.
+
+## Template-aware generation
+
+When Phase 0 has extracted a template (`template-analysis.md` exists),
+the build can optionally inject slides into the original template PPTX
+rather than generating a standalone file.
+
+**pptxgenjs limitation:** pptxgenjs does not natively support opening an
+existing PPTX and adding slides to it. The workaround is:
+
+1. Build the presentation with pptxgenjs as normal (standalone).
+2. Use the extracted template colors/fonts/assets so the output visually
+   matches the template.
+3. If exact template master slides are required (e.g., corporate footer,
+   logo placement enforced by the template's slide layouts), document
+   this as a **manual post-processing step**: open both files in
+   PowerPoint, copy slides from the generated deck into the template.
+
+**Alternative approach (python-pptx):** If the user needs true
+template-aware generation (injecting slides into the template file
+directly), suggest using python-pptx instead of pptxgenjs. python-pptx
+can open an existing PPTX and add slides using its slide layouts:
+
+```python
+from pptx import Presentation
+prs = Presentation('template.pptx')
+layout = prs.slide_layouts[1]  # Use template's layout
+slide = prs.slides.add_slide(layout)
+# ... add content using template placeholders
+prs.save('output.pptx')
+```
+
+This is a separate code path — do not mix pptxgenjs and python-pptx in
+the same build. If the user requests template-aware generation, confirm
+which approach they prefer before Phase 7 begins.
+
 ## Key Principles
 
 - **Modular** -- one file per section, always

--- a/skills/presentation-builder/references/phase-9-build.md
+++ b/skills/presentation-builder/references/phase-9-build.md
@@ -130,7 +130,77 @@ A contrast ratio below 3:1 is a **Must-fix** (text is effectively
 invisible). A ratio between 3:1 and 4.5:1 is a **Should-fix** (readable
 but fails WCAG AA).
 
-### 4. Iterate
+### 4. Export speaker notes as rehearsal document
+
+After a successful build, generate a standalone markdown file with all
+speaker notes for print-ready rehearsal:
+
+```javascript
+// Add to build.js after writeFile, or as a separate export-notes.js script
+const fs = require('fs');
+let notes = '# Speaker Notes — Rehearsal Script\n\n';
+pres.slides.forEach((slide, i) => {
+  const title = slide._slideObjects.find(o => o.options && o.options.placeholder === 'title');
+  const titleText = title ? title.text : `Slide ${i + 1}`;
+  notes += `## Slide ${i + 1}: ${titleText}\n\n`;
+  notes += (slide._speakerNotes || '_No notes_') + '\n\n---\n\n';
+});
+fs.writeFileSync('speaker-notes.md', notes);
+console.log('Speaker notes exported to speaker-notes.md');
+```
+
+The exported file should include slide numbers, titles, full notes text,
+and `---` separators between slides. This is optional — offer it to the
+user after the first successful build:
+
+> "I can also export your speaker notes as a standalone `speaker-notes.md`
+> for rehearsal. Would you like that?"
+
+### 5. HTML preview (optional, for faster iteration)
+
+The edit→build→open PowerPoint→check cycle is slow. For faster visual
+iteration, generate a lightweight HTML preview alongside the PPTX:
+
+```javascript
+// preview.js — run after build.js
+const fs = require('fs');
+const { colors, fonts } = require('./theme');
+
+function generatePreview(slides) {
+  let html = `<!DOCTYPE html><html><head>
+    <style>
+      body { font-family: ${fonts.body}, sans-serif; max-width: 960px; margin: 0 auto; }
+      .slide { border: 1px solid #ccc; margin: 20px 0; padding: 40px;
+               aspect-ratio: 16/9; position: relative; overflow: hidden; }
+      .slide.dark { background: #${colors.primary}; color: #${colors.lightText}; }
+      .slide.light { background: #${colors.contentBg}; color: #${colors.darkText}; }
+      .slide h2 { margin-top: 0; }
+      .notes { background: #fffde7; padding: 10px; font-size: 12px;
+               border-left: 3px solid #ffc107; margin-top: 10px; }
+    </style></head><body><h1>Slide Preview</h1>`;
+
+  slides.forEach((s, i) => {
+    html += `<div class="slide ${s.dark ? 'dark' : 'light'}">
+      <h2>Slide ${i + 1}: ${s.title}</h2>
+      <div>${s.content || ''}</div>
+    </div>`;
+    if (s.notes) html += `<div class="notes">${s.notes}</div>`;
+  });
+
+  html += '</body></html>';
+  fs.writeFileSync('preview.html', html);
+  console.log('Preview written to preview.html — open in browser');
+}
+```
+
+This preview is NOT a substitute for the PPTX build — it's a quick
+visual check during iteration. Offer it when the user is making
+incremental changes:
+
+> "Want me to generate an HTML preview so you can check layout in a
+> browser instead of reopening PowerPoint each time?"
+
+### 6. Iterate
 
 After validation passes, present the output to the user. Iterate based on
 feedback using the modular architecture — content changes touch one


### PR DESCRIPTION
## Summary

Addresses all 5 remaining P3 items from the field retrospective in a single PR:

- **P3-1 (#22):** HTML preview mode in Phase 9 — generates a lightweight HTML file for quick visual checking without opening PowerPoint
- **P3-2 (#23):** Template-aware generation in Phase 7 — documents pptxgenjs limitation (can't inject into existing PPTX) and python-pptx as an alternative approach
- **P3-3 (#24):** Speaker notes export in Phase 9 — generates a standalone `speaker-notes.md` for print-ready rehearsal
- **P3-4 (#25):** Cost tracking in Phase 6 — logs model used and estimated cost per image, prints a summary after all images are generated
- **P3-6 (#26):** Font fallback chain in Phase 7 — `checkFont()` function using `fc-list` warns if brand font is missing, plus fallback chain pattern in theme.js

Closes #22, closes #23, closes #24, closes #25, closes #26

## Design Decisions

- Batched all P3 items in one PR since they're independent, small additions (no conflicts)
- HTML preview and notes export are optional — offered to user, not automatic
- Font check warns but doesn't fail the build — font substitution is cosmetic
- Template-aware generation honestly documents the pptxgenjs limitation rather than pretending it works
- Cost tracking is informational only — no blocking on spend

## Test plan

- [ ] Verify Phase 6 cost tracking section has model/price table and summary format
- [ ] Verify Phase 7 font check uses `execFileSync` (not `execSync`) to avoid injection
- [ ] Verify Phase 7 template-aware section documents both pptxgenjs workaround and python-pptx alternative
- [ ] Verify Phase 9 speaker notes export generates markdown with slide titles
- [ ] Verify Phase 9 HTML preview generates browsable slide layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)